### PR TITLE
Fix trigger definitions for updated_at column

### DIFF
--- a/supabase/quick-setup.sql
+++ b/supabase/quick-setup.sql
@@ -199,22 +199,40 @@ $$ language 'plpgsql';
 
 -- Create triggers
 DROP TRIGGER IF EXISTS update_patients_updated_at ON patients;
-CREATE TRIGGER update_patients_updated_at BEFORE UPDATE ON patients FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_patients_updated_at
+    BEFORE UPDATE ON patients
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
 
 DROP TRIGGER IF EXISTS update_doctors_updated_at ON doctors;
-CREATE TRIGGER update_doctors_updated_at BEFORE UPDATE ON doctors FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_doctors_updated_at
+    BEFORE UPDATE ON doctors
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
 
 DROP TRIGGER IF EXISTS update_appointments_updated_at ON appointments;
-CREATE TRIGGER update_appointments_updated_at BEFORE UPDATE ON appointments FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_appointments_updated_at
+    BEFORE UPDATE ON appointments
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
 
 DROP TRIGGER IF EXISTS update_pending_tasks_updated_at ON pending_tasks;
-CREATE TRIGGER update_pending_tasks_updated_at BEFORE UPDATE ON pending_tasks FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_pending_tasks_updated_at
+    BEFORE UPDATE ON pending_tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
 
 DROP TRIGGER IF EXISTS update_medical_notes_updated_at ON medical_notes;
-CREATE TRIGGER update_medical_notes_updated_at BEFORE UPDATE ON medical_notes FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_medical_notes_updated_at
+    BEFORE UPDATE ON medical_notes
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
 
 DROP TRIGGER IF EXISTS update_daily_capacity_updated_at ON daily_capacity;
-CREATE TRIGGER update_daily_capacity_updated_at BEFORE UPDATE ON daily_capacity FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_daily_capacity_updated_at
+    BEFORE UPDATE ON daily_capacity
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
 
 -- =====================================================
 -- STEP 6: INITIAL DATA

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -273,12 +273,30 @@ END;
 $$ language 'plpgsql';
 
 -- Apply update_updated_at trigger to all relevant tables
-CREATE TRIGGER update_patients_updated_at BEFORE UPDATE ON patients FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_doctors_updated_at BEFORE UPDATE ON doctors FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_appointments_updated_at BEFORE UPDATE ON appointments FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_pending_tasks_updated_at BEFORE UPDATE ON pending_tasks FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_medical_notes_updated_at BEFORE UPDATE ON medical_notes FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_daily_capacity_updated_at BEFORE UPDATE ON daily_capacity FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_patients_updated_at
+    BEFORE UPDATE ON patients
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_doctors_updated_at
+    BEFORE UPDATE ON doctors
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_appointments_updated_at
+    BEFORE UPDATE ON appointments
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_pending_tasks_updated_at
+    BEFORE UPDATE ON pending_tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_medical_notes_updated_at
+    BEFORE UPDATE ON medical_notes
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_daily_capacity_updated_at
+    BEFORE UPDATE ON daily_capacity
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
 
 -- Function to automatically update appointment status based on timestamps
 CREATE OR REPLACE FUNCTION update_appointment_status()


### PR DESCRIPTION
## Summary
- reformat updated_at trigger definitions in quick-setup.sql to keep update_updated_at_column() intact on a single line
- mirror the trigger adjustments in schema.sql so the generated triggers execute the correct function name

## Testing
- not run (SQL-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8ab591a2c8328a2b1774eb3f182d4